### PR TITLE
Auto detect raw perf codes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,10 @@
-all: profile global_profile kvm_profile
+all: profile global_profile
+
+CC=gcc
 
 profile: profile.c
-	gcc -o profile profile.c
-	gcc -o global_profile global_profile.c
-	gcc -o kvm_profile kvm_profile.c
-
+global_profile: global_profile.c
 
 clean:
 	@rm -f profile
 	@rm -f global_profile
-	@rm -f kvm_profile

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 all: profile global_profile
 
 CC=gcc
+LDLIBS=-lpfm
 
 profile: profile.c
 global_profile: global_profile.c


### PR DESCRIPTION
tried using Hawkeye. saw i needed this tool to run in the background.
however it hard-codes usernames and machine types, both of which don't match my machine.
this replaces magic values with those detected by libpfm.